### PR TITLE
GeoPackage format support in the Tile Reader and Writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ To build the jar into a standalone jar that includes all dependencies:
 
 #### Tile Writer ####
 
-The tile writer writes tiles from a GeoPackage tile table to the file system.  Images are saved in a z/x/y.ext folder & file structure formatted as GeoPackage, Standard (Google), or TMS (Tile Map Service).  The mil.nga.geopackage.io.TileWriter functionality is invokable through code or command line.
+The tile writer writes tiles from a GeoPackage tile table to the file system.  Images are saved as raw bytes or as a specified format in a z/x/y.ext folder & file structure formatted as GeoPackage, Standard (Google), or TMS (Tile Map Service).  The GeoPackage format writes a tiles.properties file in the base imagery directory.  The mil.nga.geopackage.io.TileWriter functionality is invokable through code or command line.
 
 To run against the jar:
 
@@ -104,7 +104,7 @@ Example:
 
 #### Tile Reader ####
 
-The tile reader reads tile images from the file system and saves them into a new or existing GeoPackage in a new tile table. Images structured in a z/x/y.ext folder & file structure formatted as Standard (Google) or TMS (Tile Map Service) are supported.  The mil.nga.geopackage.io.TileReader functionality is invokable through code or command line.
+The tile reader reads tile images from the file system and saves them into a new or existing GeoPackage in a new tile table. Images structured in a z/x/y.ext folder & file structure formatted as GeoPackage, Standard (Google), or TMS (Tile Map Service) are saved as raw bytes or as a specified format in a GeoPackage.  The GeoPackage format requires a tiles.properties file in the base imagery directory.  The mil.nga.geopackage.io.TileReader functionality is invokable through code or command line.
 
 To run against the jar:
 
@@ -113,6 +113,19 @@ To run against the jar:
 Example:
 
     java -classpath geopackage-*standalone.jar mil.nga.geopackage.io.TileReader -i png /path/tiles/mytiles standard /path/geopackage.gpkg mytiletable
+
+GeoPackage Format tiles.properties:
+
+    epsg=
+    min_x=
+    max_x=
+    min_y=
+    max_y=
+    # Zoom Level Properties:
+    # If the file strucThe GeoPackage format requires a tiles.properties file in the base imagery directory.ture is fully populated and represents the matrix width and height, the properties can be omitted
+    # If a non top zoom level matrix width and height increase by a factor of 2 with each zoom level, the properties can be omitted for those zoom levels
+    zoom_level.{zoom}.matrix_width=
+    zoom_level.{zoom}.matrix_height=
 
 ### Dependencies ###
 

--- a/src/main/java/mil/nga/geopackage/io/TileProperties.java
+++ b/src/main/java/mil/nga/geopackage/io/TileProperties.java
@@ -1,0 +1,273 @@
+package mil.nga.geopackage.io;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import mil.nga.geopackage.GeoPackageException;
+import mil.nga.geopackage.tiles.matrix.TileMatrix;
+import mil.nga.geopackage.tiles.matrixset.TileMatrixSet;
+import mil.nga.geopackage.tiles.user.TileDao;
+
+/**
+ * Tile properties for GeoPackage formatted tile property files
+ * 
+ * @author osbornb
+ */
+public class TileProperties {
+
+	/**
+	 * Logger
+	 */
+	private static final Logger LOGGER = Logger.getLogger(TileProperties.class
+			.getName());
+
+	/**
+	 * GeoPackage tiles properties file
+	 */
+	public static final String GEOPACKAGE_PROPERTIES_FILE = "tiles.properties";
+
+	/**
+	 * SRS ID property
+	 */
+	public static final String GEOPACKAGE_PROPERTIES_EPSG = "epsg";
+
+	/**
+	 * MIN X property
+	 */
+	public static final String GEOPACKAGE_PROPERTIES_MIN_X = "min_x";
+
+	/**
+	 * MAX X property
+	 */
+	public static final String GEOPACKAGE_PROPERTIES_MAX_X = "max_x";
+
+	/**
+	 * MIN Y property
+	 */
+	public static final String GEOPACKAGE_PROPERTIES_MIN_Y = "min_y";
+
+	/**
+	 * MAX Y property
+	 */
+	public static final String GEOPACKAGE_PROPERTIES_MAX_Y = "max_y";
+
+	/**
+	 * Zoom Level property
+	 */
+	public static final String GEOPACKAGE_PROPERTIES_ZOOM_LEVEL = "zoom_level";
+
+	/**
+	 * Matrix Width property
+	 */
+	public static final String GEOPACKAGE_PROPERTIES_MATRIX_WIDTH = "matrix_width";
+
+	/**
+	 * Matrix Height property
+	 */
+	public static final String GEOPACKAGE_PROPERTIES_MATRIX_HEIGHT = "matrix_height";
+
+	/**
+	 * Properties file to read or write
+	 */
+	private File propertiesFile;
+
+	/**
+	 * Loaded Properties
+	 */
+	private Properties properties;
+
+	/**
+	 * Constructor
+	 * 
+	 * @param directory
+	 * @return
+	 */
+	public TileProperties(File directory) {
+		this.propertiesFile = new File(directory, GEOPACKAGE_PROPERTIES_FILE);
+	}
+
+	/**
+	 * Load the properties
+	 */
+	public void load() {
+		properties = new Properties();
+
+		try {
+			InputStream in = new FileInputStream(propertiesFile);
+
+			try {
+				properties.load(in);
+			} catch (Exception e) {
+				throw new GeoPackageException(
+						"Failed to load properties file for GeoPackage file format located at: "
+								+ propertiesFile, e);
+			} finally {
+				try {
+					in.close();
+				} catch (IOException e) {
+					LOGGER.log(Level.WARNING,
+							"Failed to close properties file: "
+									+ propertiesFile, e);
+				}
+			}
+		} catch (FileNotFoundException e) {
+			throw new GeoPackageException(
+					"GeoPackage file format requires a properties file located at: "
+							+ propertiesFile, e);
+		}
+	}
+
+	/**
+	 * Get the Integer property
+	 * 
+	 * @param property
+	 * @param required
+	 * @return
+	 */
+	public Integer getIntegerProperty(String property, boolean required) {
+		Integer integerValue = null;
+		String value = getProperty(property, required);
+		if (value != null) {
+			try {
+				integerValue = Integer.valueOf(value);
+			} catch (NumberFormatException e) {
+				throw new GeoPackageException(GEOPACKAGE_PROPERTIES_FILE
+						+ " property file property '" + property
+						+ "' must be an integer");
+			}
+		}
+		return integerValue;
+	}
+
+	/**
+	 * Get the Double property
+	 * 
+	 * @param property
+	 * @param required
+	 * @return
+	 */
+	public Double getDoubleProperty(String property, boolean required) {
+		Double doubleValue = null;
+		String value = getProperty(property, required);
+		if (value != null) {
+			try {
+				doubleValue = Double.valueOf(value);
+			} catch (NumberFormatException e) {
+				throw new GeoPackageException(GEOPACKAGE_PROPERTIES_FILE
+						+ " property file property '" + property
+						+ "' must be a double");
+			}
+		}
+		return doubleValue;
+	}
+
+	/**
+	 * Get the String property
+	 * 
+	 * @param property
+	 * @param required
+	 * @return
+	 */
+	public String getProperty(String property, boolean required) {
+
+		if (properties == null) {
+			throw new GeoPackageException(
+					"Properties must be loaded before reading");
+		}
+
+		String value = properties.getProperty(property);
+		if (value == null && required) {
+			throw new GeoPackageException(GEOPACKAGE_PROPERTIES_FILE
+					+ " property file missing required property: " + property);
+		}
+		return value;
+	}
+
+	/**
+	 * Write the properties file using the tile dao
+	 * 
+	 * @param tileDao
+	 */
+	public void writeFile(TileDao tileDao) {
+		try {
+			PrintWriter pw = new PrintWriter(propertiesFile);
+
+			TileMatrixSet tileMatrixSet = tileDao.getTileMatrixSet();
+			pw.println(GEOPACKAGE_PROPERTIES_EPSG + "="
+					+ tileMatrixSet.getSrs().getOrganizationCoordsysId());
+			pw.println(GEOPACKAGE_PROPERTIES_MIN_X + "="
+					+ tileMatrixSet.getMinX());
+			pw.println(GEOPACKAGE_PROPERTIES_MAX_X + "="
+					+ tileMatrixSet.getMaxX());
+			pw.println(GEOPACKAGE_PROPERTIES_MIN_Y + "="
+					+ tileMatrixSet.getMinY());
+			pw.println(GEOPACKAGE_PROPERTIES_MAX_Y + "="
+					+ tileMatrixSet.getMaxY());
+
+			for (TileMatrix tileMatrix : tileDao.getTileMatrices()) {
+				long zoom = tileMatrix.getZoomLevel();
+				pw.println(getMatrixWidthProperty(zoom) + "="
+						+ tileMatrix.getMatrixWidth());
+				pw.println(getMatrixHeightProperty(zoom) + "="
+						+ tileMatrix.getMatrixHeight());
+			}
+
+			pw.close();
+
+		} catch (FileNotFoundException e) {
+			throw new GeoPackageException(
+					"GeoPackage file format properties file could not be created: "
+							+ propertiesFile, e);
+		}
+	}
+
+	/**
+	 * Get the matrix width property for the zoom level
+	 * 
+	 * @param zoom
+	 * @return
+	 */
+	public static String getMatrixWidthProperty(long zoom) {
+		return getMatrixWidthProperty(String.valueOf(zoom));
+	}
+
+	/**
+	 * Get the matrix width property for the zoom level
+	 * 
+	 * @param zoom
+	 * @return
+	 */
+	public static String getMatrixWidthProperty(String zoom) {
+		return GEOPACKAGE_PROPERTIES_ZOOM_LEVEL + "." + zoom + "."
+				+ GEOPACKAGE_PROPERTIES_MATRIX_WIDTH;
+	}
+
+	/**
+	 * Get the matrix height property for the zoom level
+	 * 
+	 * @param zoom
+	 * @return
+	 */
+	public static String getMatrixHeightProperty(long zoom) {
+		return getMatrixHeightProperty(String.valueOf(zoom));
+	}
+
+	/**
+	 * Get the matrix height property for the zoom level
+	 * 
+	 * @param zoom
+	 * @return
+	 */
+	public static String getMatrixHeightProperty(String zoom) {
+		return GEOPACKAGE_PROPERTIES_ZOOM_LEVEL + "." + zoom + "."
+				+ GEOPACKAGE_PROPERTIES_MATRIX_HEIGHT;
+	}
+
+}

--- a/src/main/java/mil/nga/geopackage/io/TileReader.java
+++ b/src/main/java/mil/nga/geopackage/io/TileReader.java
@@ -89,6 +89,11 @@ public class TileReader {
 			.getName());
 
 	/**
+	 * Progress log frequency within a zoom level
+	 */
+	private static final int ZOOM_PROGRESS_FREQUENCY = 100;
+
+	/**
 	 * Main method to read tiles from the file system into a GeoPackage
 	 * 
 	 * @param args
@@ -588,6 +593,11 @@ public class TileReader {
 						tileDao.create(newRow);
 
 						zoomCount++;
+
+						if (zoomCount % ZOOM_PROGRESS_FREQUENCY == 0) {
+							LOGGER.log(Level.INFO, "Zoom " + zoomDirectory.zoom
+									+ " Tile Progress... " + zoomCount);
+						}
 					}
 				}
 

--- a/src/main/java/mil/nga/geopackage/io/TileWriter.java
+++ b/src/main/java/mil/nga/geopackage/io/TileWriter.java
@@ -77,6 +77,11 @@ public class TileWriter {
 			.getName());
 
 	/**
+	 * Progress log frequency within a zoom level
+	 */
+	private static final int ZOOM_PROGRESS_FREQUENCY = 100;
+
+	/**
 	 * Main method to write tiles from a GeoPackage
 	 * 
 	 * @param args
@@ -360,6 +365,11 @@ public class TileWriter {
 						}
 
 						tileCount++;
+
+						if (tileCount % ZOOM_PROGRESS_FREQUENCY == 0) {
+							LOGGER.log(Level.INFO, "Zoom " + zoomLevel
+									+ " Tile Progress... " + tileCount);
+						}
 					}
 				}
 			}
@@ -453,6 +463,11 @@ public class TileWriter {
 					}
 
 					tileCount++;
+
+					if (tileCount % ZOOM_PROGRESS_FREQUENCY == 0) {
+						LOGGER.log(Level.INFO, "Zoom " + zoomLevel
+								+ " Tile Progress... " + tileCount);
+					}
 				}
 
 			}

--- a/src/main/java/mil/nga/geopackage/io/TileWriter.java
+++ b/src/main/java/mil/nga/geopackage/io/TileWriter.java
@@ -292,6 +292,13 @@ public class TileWriter {
 			totalCount += zoomCount;
 		}
 
+		// If GeoPackage format, write a properties file
+		if (tileType == TileFormatType.GEOPACKAGE) {
+			tileDao = geoPackage.getTileDao(tileTable);
+			TileProperties tileProperties = new TileProperties(directory);
+			tileProperties.writeFile(tileDao);
+		}
+
 		LOGGER.log(Level.INFO, "Total Tiles: " + totalCount);
 	}
 


### PR DESCRIPTION
Create property file when writing GeoPackage tiles to the file system. Read GeoPackage format tiles from the file system into a GeoPackage, using the required property file defining bounds and dimensions. Log progress when reading or writing tiles, every 100 tiles.