### PR TITLE
build: do not include slf4j binding as library dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-nop</artifactId>
 			<version>2.0.12</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
Including the slf4j binding causes problems in any downstream application that intends to use a different slf4j binding (e.g. slf4j-simple, logback, etc.).

Fixes #62